### PR TITLE
Update blitz.md

### DIFF
--- a/docs/api/blitz.md
+++ b/docs/api/blitz.md
@@ -2,7 +2,7 @@
 title: Blitz.js
 ---
 
-Since Blitz.js users use the Next.js Quirrel client, the [Next.js API Reference](api/next) works fine for Blitz users.
+Since Blitz.js users use the Next.js Quirrel client, the [Next.js API Reference](./next.md) works fine for Blitz users.
 
 :::caution
 Until v0.26.0, there has been a bug that made you face a `Module not found` error when working with Quirrel.


### PR DESCRIPTION
Fix broken link "Next.js API Reference" (https://github.com/quirrel-dev/docs.quirrel.dev/blob/main/docs/api/api/next) to correct link (https://github.com/quirrel-dev/docs.quirrel.dev/blob/main/docs/api/next.md)

After fix linking works as expected.