### PR TITLE
Fix broken hyperlink (same as other PR)

### DIFF
--- a/docs/docs/getting-started/blitz-js.md
+++ b/docs/docs/getting-started/blitz-js.md
@@ -2,4 +2,4 @@
 title: Blitz.js
 ---
 
-Since Blitz.js is based on Next.js, the [Getting-Started for Next.js](/docs/getting-started/next-js) can be applied to Blitz as well.
+Since Blitz.js is based on Next.js, the [Getting-Started for Next.js](/docs/docs/getting-started/next-js.md) can be applied to Blitz as well.


### PR DESCRIPTION
Update link from (/docs/getting-started/next-js) to (/docs/docs/getting-started/next-js.md)

This change fixes broken link sending to 404.  

Possible proposal for future that you have identical docs in two separate areas of this repo which I'm confused about the need?  

Thanks, hope this helps even slightly!  (looking to help more in OSS).